### PR TITLE
Add collect for get_harvesters

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,22 @@ chia_plots_failed_to_open 0
 # HELP chia_plots_not_found Number of plots files not found.
 # TYPE chia_plots_not_found gauge
 chia_plots_not_found 0
+# HELP chia_farmer_harvesters Number of harvesters connected to the farmer.
+# TYPE chia_farmer_harvesters gauge
+chia_farmer_harvesters 2
+# HELP chia_farmer_plots Number of plots currently harvesting.
+# TYPE chia_farmer_plots gauge
+chia_farmer_plots{harvester="127.0.0.1",node_id="e661ef5a92be",pool_contract_puzzle_hash="",pool_public_key="0x...",size="32"} 273
+chia_farmer_plots{harvester="127.0.0.1",node_id="e661ef5a92be",pool_contract_puzzle_hash="0x...",pool_public_key="",size="32"} 260
+chia_farmer_plots{harvester="192.168.1.100",node_id="99573777c042",pool_contract_puzzle_hash="0x...",pool_public_key="",size="32"} 90
+# HELP chia_farmer_plots_failed_to_open Number of plot files failed to open.
+# TYPE chia_farmer_plots_failed_to_open gauge
+chia_farmer_plots_failed_to_open{harvester="127.0.0.1",node_id="e661ef5a92be"} 10
+chia_farmer_plots_failed_to_open{harvester="192.168.1.100",node_id="99573777c042"} 0
+# HELP chia_farmer_plots_no_key Number of plots with no key.
+# TYPE chia_farmer_plots_no_key gauge
+chia_farmer_plots_no_key{harvester="127.0.0.1",node_id="e661ef5a92be"} 0
+chia_farmer_plots_no_key{harvester="192.168.1.100",node_id="99573777c042"} 0
 ```
 
 ### Blockchain and Connections (full node)
@@ -160,6 +176,9 @@ endpoint. The wallet metrics are collected for each wallet, and include
 
 * Pool state is collected from the
   [get_pool_state](https://github.com/Chia-Network/chia-blockchain/wiki/RPC-Interfaces#get_pool_state)
+  endpoint (not yet documented). Need chia client version 1.2.0 or later
+
+* Harvesters are collected from [get_harvesters](https://github.com/Chia-Network/chia-blockchain/wiki/RPC-Interfaces#get_harvesters)
   endpoint (not yet documented). Need chia client version 1.2.0 or later
 
 ### Plots (harvester)

--- a/chia.go
+++ b/chia.go
@@ -171,3 +171,17 @@ type PlotFiles struct {
 	Plots        []PlotData `json:"plots"`
 	Success      bool
 }
+
+type Harvesters struct {
+	Harvesters []struct {
+		Connection struct {
+			Host   string `json:"host"`
+			NodeId string `json:"node_id"`
+			Port   int64  `json:"port"`
+		} `json:"connection"`
+		FailedToOpenFilenames []string   `json:"failed_to_open_filenames"`
+		NoKeyFilenames        []string   `json:"no_key_filenames"`
+		Plots                 []PlotData `json:"plots"`
+	} `json:"harvesters"`
+	Success bool `json:"success"`
+}

--- a/main.go
+++ b/main.go
@@ -148,6 +148,7 @@ func (cc ChiaCollector) Collect(ch chan<- prometheus.Metric) {
 	cc.collectWallets(ch)
 	cc.collectPoolState(ch)
 	cc.collectPlots(ch)
+	cc.collectFarmerHarvesters(ch)
 }
 
 func (cc ChiaCollector) collectConnections(ch chan<- prometheus.Metric) {
@@ -527,4 +528,67 @@ func (cc ChiaCollector) collectFarmedAmount(ch chan<- prometheus.Metric, w Walle
 		float64(farmed.PoolRewardAmount),
 		w.StringID, w.PublicKey,
 	)
+}
+
+func (cc ChiaCollector) collectFarmerHarvesters(ch chan<- prometheus.Metric) {
+	var harvesters Harvesters
+	if err := queryAPI(cc.client, cc.farmerURL, "get_harvesters", "", &harvesters); err != nil {
+		log.Print(err)
+		return
+	}
+	ch <- prometheus.MustNewConstMetric(
+		prometheus.NewDesc(
+			"chia_farmer_harvesters",
+			"Number of harvesters connected to the farmer.",
+			nil, nil,
+		),
+		prometheus.GaugeValue,
+		float64(len(harvesters.Harvesters)),
+	)
+	for _, h := range harvesters.Harvesters {
+		ch <- prometheus.MustNewConstMetric(
+			prometheus.NewDesc(
+				"chia_farmer_plots_failed_to_open",
+				"Number of plot files failed to open.",
+				[]string{"harvester", "node_id"}, nil,
+			),
+			prometheus.GaugeValue,
+			float64(len(h.FailedToOpenFilenames)),
+			h.Connection.Host,
+			h.Connection.NodeId[0:12],
+		)
+		ch <- prometheus.MustNewConstMetric(
+			prometheus.NewDesc(
+				"chia_farmer_plots_no_key",
+				"Number of plots with no key.",
+				[]string{"harvester", "node_id"}, nil,
+			),
+			prometheus.GaugeValue,
+			float64(len(h.NoKeyFilenames)),
+			h.Connection.Host,
+			h.Connection.NodeId[0:12],
+		)
+		plots := make(map[[3]string]float64)
+		for _, p := range h.Plots {
+			s := strconv.FormatInt(int64(p.Size), 10)
+			plots[[3]string{p.PoolPublicKey, p.PoolContract, s}]++
+		}
+		plotsDesc := prometheus.NewDesc(
+			"chia_farmer_plots",
+			"Number of plots currently harvesting.",
+			[]string{"harvester", "node_id", "pool_public_key", "pool_contract_puzzle_hash", "size"}, nil,
+		)
+		for k, v := range plots {
+			ch <- prometheus.MustNewConstMetric(
+				plotsDesc,
+				prometheus.GaugeValue,
+				v,
+				h.Connection.Host,
+				h.Connection.NodeId[0:12],
+				k[0],
+				k[1],
+				k[2],
+			)
+		}
+	}
 }


### PR DESCRIPTION
Forking https://github.com/retzkek/chia_exporter/pull/10, original PR description below:

> This collects metrics from the farmer get_harvesters endpoint (mentioned in the chia-blockhain v1.2.0 release notes but not documented in the wiki). Most of the same data as get_plots from the harvester is collected but this collects once for all remote/connected harvesters. Metrics for plot count have labels for pool_public_key, pool_contract_puzzle_hash and size. These labels can be used to tell if a plot is portable or solo or if you plot different size plots etc.

> sum(chia_farmer_plots{pool_contract_puzzle_hash!=""}) - total portable plots across all harvesters
sum(chia_farmer_plots{pool_public_key!=""}) - total solo plots across all harvesters
This may obsolete func collectPlots.